### PR TITLE
Neos v3.3 compatibility + 1.2.0 feature (enhanced checkbox)

### DIFF
--- a/Classes/CRON/FormBuilder/Controller/FormBuilderController.php
+++ b/Classes/CRON/FormBuilder/Controller/FormBuilderController.php
@@ -2,7 +2,7 @@
 namespace CRON\FormBuilder\Controller;
 
 /*                                                                        *
- * This script belongs to the TYPO3 Flow package "CRON.FormBuilder".      *
+ * This script belongs to the Neos Flow package "CRON.FormBuilder".       *
  *                                                                        *
  *                                                                        */
 

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -259,7 +259,7 @@
 
 'CRON.FormBuilder:CheckBoxEnhanced':
   superTypes:
-    'TYPO3.Neos:Content': true
+    'Neos.Neos:Content': true
     'CRON.FormBuilder:CheckBox': true
   ui:
     label: CRON.FormBuilder:NodeTypes.Plugin:fields.checkbox.enhanced
@@ -282,7 +282,7 @@
         reloadIfChanged: true
         inspector:
           group: options
-          editor: 'TYPO3.Neos/Inspector/Editors/TextAreaEditor'
+          editor: 'Neos.Neos/Inspector/Editors/TextAreaEditor'
           editorOptions:
             rows: 10
 

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -75,6 +75,7 @@
           'CRON.FormBuilder:Select': true
           'CRON.FormBuilder:CheckBox': true
           'CRON.FormBuilder:CheckBoxGroup': true
+          'CRON.FormBuilder:CheckBoxEnhanced': true
           'CRON.FormBuilder:TextArea': true
           'CRON.FormBuilder:FileUpload': true
           '*': false
@@ -254,6 +255,36 @@
         reloadIfChanged: true
         inspector:
           group: options
+
+
+'CRON.FormBuilder:CheckBoxEnhanced':
+  superTypes:
+    'TYPO3.Neos:Content': true
+    'CRON.FormBuilder:CheckBox': true
+  ui:
+    label: CRON.FormBuilder:NodeTypes.Plugin:fields.checkbox.enhanced
+  properties:
+    text:
+      type: string
+      ui:
+        label: Text
+        inlineEditable: true
+        aloha:
+          placeholder: CRON.FormBuilder:NodeTypes.Plugin:fields.checkbox.enhanced.text
+          format:
+            'p': true
+          link:
+            'a': true
+    mainText:
+      type: string
+      ui:
+        label: CRON.FormBuilder:NodeTypes.Plugin:fields.checkbox.enhanced.mainText
+        reloadIfChanged: true
+        inspector:
+          group: options
+          editor: 'TYPO3.Neos/Inspector/Editors/TextAreaEditor'
+          editorOptions:
+            rows: 10
 
 
 'CRON.FormBuilder:TextArea':

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In your site package NodeTypes.yaml add the FormBuilder plugin like:
 ```
 childNodes:
     main:
-      type: 'TYPO3.Neos:ContentCollection'
+      type: 'Neos.Neos:ContentCollection'
       constraints:
         nodeTypes:
           'CRON.FormBuilder:Plugin': true

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -40,6 +40,14 @@ prototype(CRON.FormBuilder:CheckBox) < prototype(CRON.FormBuilder:FormElement) {
 	checked = ${this.value || q(node).property('checked')}
 }
 
+prototype(CRON.FormBuilder:CheckBoxEnhanced) < prototype(CRON.FormBuilder:FormElement) {
+	layoutName = 'CheckboxWrapper'
+	attributes.class = ''
+	checked = ${this.value || q(node).property('checked')}
+	text = ${q(node).property('text')}
+	mainText = ${q(node).property('mainText')}
+}
+
 prototype(CRON.FormBuilder:CheckBoxGroup) < prototype(CRON.FormBuilder:FormElement) {
 
 	@context.groupValue = ${this.value}
@@ -58,7 +66,6 @@ prototype(CRON.FormBuilder:CheckBoxGroup) < prototype(CRON.FormBuilder:FormEleme
 		}
 	}
 }
-
 
 prototype(CRON.FormBuilder:Input) < prototype(CRON.FormBuilder:FormElement) {
 

--- a/Resources/Private/Templates/FormBuilder/Index.html
+++ b/Resources/Private/Templates/FormBuilder/Index.html
@@ -9,6 +9,9 @@
 		</f:if>
 		<ts:render path="elements" typoScriptPackageKey="{tsPackageKey}" context="{node: elements}"/>
 		<f:form.hidden name="__formId" value="{node.identifier}"></f:form.hidden>
+		<div>
+			<p><span>* </span><f:translate id="formBuilder.requiredField" package="CRON.FormBuilder"/></p>
+		</div>
 		<button type="submit" class="btn btn-default">{submitButtonLabel}</button>
 	</f:form>
 	<f:if condition="{neos:rendering.inBackend(node: documentNode)}">

--- a/Resources/Private/Templates/NodeTypes/CheckBoxEnhanced.html
+++ b/Resources/Private/Templates/NodeTypes/CheckBoxEnhanced.html
@@ -1,0 +1,32 @@
+{namespace neos=TYPO3\Neos\ViewHelpers}
+<f:layout name="{layoutName}" />
+<f:section name="Content">
+    <div class="checkbox-enhanced {f:if(condition: validationResults.flattenedErrors, then: 'has-error')}">
+        <f:if condition="{neos:rendering.inBackend()}">
+            <f:then>
+                <f:if condition="{mainText}">
+                    <div>
+                        {mainText -> f:format.raw()}
+                    </div>
+                </f:if>
+                <label>
+                    <input {attributes -> f:format.raw()} type="checkbox" onclick="return false;"/> {neos:contentElement.editable(property: 'text', tag: 'p')}
+                </label>
+            </f:then>
+            <f:else>
+                <f:if condition="{mainText}">
+                    <div>
+                        {mainText -> f:format.raw()}
+                    </div>
+                </f:if>
+                <div class="checkbox-enhanced-label">
+                    <input {attributes -> f:format.raw()} type="hidden" value="">
+                    <input {attributes -> f:format.raw()} type="checkbox" value="{node.properties.value}" {f:if(condition: checked, then: 'checked')}/>
+                    <label>
+                        {text -> f:format.raw()}
+                    </label>
+                </div>
+            </f:else>
+        </f:if>
+    </div>
+</f:section>

--- a/Resources/Private/Templates/NodeTypes/CheckBoxEnhanced.html
+++ b/Resources/Private/Templates/NodeTypes/CheckBoxEnhanced.html
@@ -1,4 +1,4 @@
-{namespace neos=TYPO3\Neos\ViewHelpers}
+{namespace neos=Neos\Neos\ViewHelpers}
 <f:layout name="{layoutName}" />
 <f:section name="Content">
     <div class="checkbox-enhanced {f:if(condition: validationResults.flattenedErrors, then: 'has-error')}">

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -22,6 +22,10 @@
         <source>Following errors occurred:</source>
         <target xml:lang="de" state="translated">Folgende Fehler sind aufgetreten:</target>
       </trans-unit>
+      <trans-unit id="formBuilder.requiredField" xml:space="preserve">
+        <source>This field is required</source>
+        <target xml:lang="de" state="translated">Dies ist ein Pflichtfeld</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/de/NodeTypes/Plugin.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Plugin.xlf
@@ -130,6 +130,18 @@
         <source>Checkbox</source>
         <target xml:lang="de" state="translated">Auswahlkasten</target>
       </trans-unit>
+      <trans-unit id="fields.checkbox.enhanced" xml:space="preserve">
+        <source>Enhanced-Checkbox</source>
+        <target xml:lang="de" state="translated">Erweitertes-Auswahlkasten</target>
+      </trans-unit>
+      <trans-unit id="fields.checkbox.enhanced.text" xml:space="preserve">
+        <source>Enter text here ...</source>
+        <target xml:lang="de" state="translated">Text hier eingeben ...</target>
+      </trans-unit>
+      <trans-unit id="fields.checkbox.enhanced.mainText" xml:space="preserve">
+        <source>Main-Text</source>
+        <target xml:lang="de" state="translated">Haupt-Text</target>
+      </trans-unit>
       <trans-unit id="fields.checkbox.group" xml:space="preserve">
         <source>Checkbox-Group</source>
         <target xml:lang="de" state="translated">Auswahlkasten-Gruppe</target>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -17,6 +17,9 @@
       <trans-unit id="formBuilder.index.errors.title" xml:space="preserve">
         <source>Following errors occurred:</source>
       </trans-unit>
+      <trans-unit id="formBuilder.requiredField" xml:space="preserve">
+        <source>This field is required</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Plugin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Plugin.xlf
@@ -98,6 +98,15 @@
       <trans-unit id="fields.checkbox" xml:space="preserve">
         <source>Checkbox</source>
       </trans-unit>
+      <trans-unit id="fields.checkbox.enhanced" xml:space="preserve">
+        <source>Enhanced-Checkbox</source>
+      </trans-unit>
+      <trans-unit id="fields.checkbox.enhanced.text" xml:space="preserve">
+        <source>Enter text here ...</source>
+      </trans-unit>
+      <trans-unit id="fields.checkbox.enhanced.mainText" xml:space="preserve">
+        <source>Main-Text</source>
+      </trans-unit>
       <trans-unit id="fields.checkbox.group" xml:space="preserve">
         <source>Checkbox-Group</source>
       </trans-unit>


### PR DESCRIPTION
This PR contains the latest changes(DAVSHOP-760) from branch develop-1.1 (compatible with Neos v2.3), adapted to fit Neos v3.3

See:
- https://github.com/cron-eu/davshop-base/pull/671
- https://github.com/cron-eu/neos-formbuilder/pull/21

After merging, we should create release 2.1.0 for the upgraded version of DAVShop site.