### PR TITLE
Swiftmailer compatibility fix

### DIFF
--- a/Classes/CRON/FormBuilder/Utils/EmailMessage.php
+++ b/Classes/CRON/FormBuilder/Utils/EmailMessage.php
@@ -55,12 +55,13 @@ class EmailMessage
      * Attaches an file to the email
      * @param NodeInterface $node
      * @param array $data
+     * @throws \Neos\ContentRepository\Exception\NodeException
      */
     public function addAttachment($node, $data)
     {
 
         $this->mail->attach(
-            \Swift_Attachment::newInstance(
+            new \Swift_Attachment(
                 file_get_contents($data['tmp_name']),
                 join('-', [$node->getProperty('label'), $data['name']]),
                 $data['type']

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "neos/neos": "^3.3.0",
         "neos/swiftmailer": "~6.0.0",
-        "neos/nodetypes": "~3.3.0"
+        "neos/nodetypes": "~3.3.0",
+        "swiftmailer/swiftmailer": "^6.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "neos/neos": "^3.3.0",
         "neos/swiftmailer": "~6.0.0",
         "neos/nodetypes": "~3.3.0",
-        "swiftmailer/swiftmailer": "^6.0"
+        "swiftmailer/swiftmailer": "^6.0 || ^5.4"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This PR removes deprecated method newInstance and instantiate object passing the args to the constructor.
Update of the neos/swiftmailer package from 6.0.2 -> 6.0.4 required update of swiftmailer/swiftmailer library from 5.4.9 -> 6+ (in our case 6.1.3). 
Here are the library changes: https://github.com/swiftmailer/swiftmailer/blob/master/CHANGES
