### PR TITLE
New "Text" element for forms and "Required field" text no longer hardcoded

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -78,6 +78,7 @@
           'CRON.FormBuilder:CheckBoxEnhanced': true
           'CRON.FormBuilder:TextArea': true
           'CRON.FormBuilder:FileUpload': true
+          'CRON.FormBuilder:Text': true
           '*': false
 
 'CRON.FormBuilder:FormElementLabelMixin':
@@ -318,3 +319,17 @@
     'CRON.FormBuilder:FormElementRequiredMixin': true
   ui:
     label: CRON.FormBuilder:NodeTypes.Plugin:fields.fileupload
+
+'CRON.FormBuilder:Text':
+  superTypes:
+    'Neos.Neos:Content': true
+  ui:
+    label: CRON.FormBuilder:NodeTypes.Plugin:fields.text
+    icon: 'icon-edit-sign'
+  properties:
+    text:
+      type: string
+      ui:
+        inlineEditable: true
+        aloha:
+          placeholder: CRON.FormBuilder:NodeTypes.Plugin:fields.text.placeholder

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -105,6 +105,9 @@ prototype(CRON.FormBuilder:FileUpload) < prototype(CRON.FormBuilder:FormElement)
 	allowedMimeTypes = ${Array.join(Configuration.setting('CRON.FormBuilder.Upload.allowedMimeTypes'), ',')}
 }
 
+prototype(CRON.FormBuilder:Text) < prototype(CRON.FormBuilder:FormElement) {
+	text = ${q(node).property('text')}
+}
 
 prototype(CRON.FormBuilder:Plugin) < prototype(Neos.Neos:Plugin) {
 	package = 'CRON.FormBuilder'

--- a/Resources/Private/Templates/FormBuilder/Index.html
+++ b/Resources/Private/Templates/FormBuilder/Index.html
@@ -9,9 +9,6 @@
 		</f:if>
 		<ts:render path="elements" typoScriptPackageKey="{tsPackageKey}" context="{node: elements}"/>
 		<f:form.hidden name="__formId" value="{node.identifier}"></f:form.hidden>
-		<div>
-			<p><span>* </span><f:translate id="formBuilder.requiredField" package="CRON.FormBuilder"/></p>
-		</div>
 		<button type="submit" class="btn btn-default">{submitButtonLabel}</button>
 	</f:form>
 	<f:if condition="{neos:rendering.inBackend(node: documentNode)}">

--- a/Resources/Private/Templates/NodeTypes/Text.html
+++ b/Resources/Private/Templates/NodeTypes/Text.html
@@ -1,0 +1,12 @@
+{namespace neos=Neos\Neos\ViewHelpers}
+<f:layout name="{layoutName}" />
+<f:section name="Content">
+	<f:if condition="{neos:rendering.inBackend()}">
+		<f:then>
+			<p>{neos:contentElement.editable(property: 'text')}</p>
+		</f:then>
+		<f:else>
+			<p>{text -> f:format.raw()}</p>
+		</f:else>
+	</f:if>
+</f:section>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -22,10 +22,6 @@
         <source>Following errors occurred:</source>
         <target xml:lang="de" state="translated">Folgende Fehler sind aufgetreten:</target>
       </trans-unit>
-      <trans-unit id="formBuilder.requiredField" xml:space="preserve">
-        <source>This field is required</source>
-        <target xml:lang="de" state="translated">Dies ist ein Pflichtfeld</target>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/de/NodeTypes/Plugin.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Plugin.xlf
@@ -158,6 +158,14 @@
         <source>File-Upload</source>
         <target xml:lang="de" state="translated">Datei-Upload</target>
       </trans-unit>
+      <trans-unit id="fields.text" xml:space="preserve">
+        <source>Text</source>
+        <target xml:lang="de" state="translated">Text</target>
+      </trans-unit>
+      <trans-unit id="fields.text.placeholder" xml:space="preserve">
+        <source>Enter text here</source>
+        <target xml:lang="de" state="translated">Text hier eingeben</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -17,9 +17,6 @@
       <trans-unit id="formBuilder.index.errors.title" xml:space="preserve">
         <source>Following errors occurred:</source>
       </trans-unit>
-      <trans-unit id="formBuilder.requiredField" xml:space="preserve">
-        <source>This field is required</source>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Plugin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Plugin.xlf
@@ -119,6 +119,12 @@
       <trans-unit id="fields.fileupload" xml:space="preserve">
         <source>File-Upload</source>
       </trans-unit>
+      <trans-unit id="fields.text" xml:space="preserve">
+        <source>Text</source>
+      </trans-unit>
+      <trans-unit id="fields.text.placeholder" xml:space="preserve">
+        <source>Enter text here</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Added a feature to have generic "Text" blocks in the form.

The "This is a Pflichtfeld" text is no longer hardcoded, but instead can be added as a "Text" by the editor.

Reference:
https://cron-eu.atlassian.net/browse/DAVSHOP-857