### PR TITLE
Enhanced checkboxes block sending form if they are "required" fields

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -264,6 +264,10 @@
   ui:
     label: CRON.FormBuilder:NodeTypes.Plugin:fields.checkbox.enhanced
   properties:
+    label:
+      defaultValue: 'Agreement'
+    value:
+      defaultValue: 'accepted'
     text:
       type: string
       ui:


### PR DESCRIPTION
If the `enhanced checkbox` is *required*  field in the form, `NotEmptyValidatior` will be triggered and form could not be properly validated (and sent).
Values considered as empty are:
- null
- empty string
- empty array
- countable empty object

We define default values for **label** and **value** properties.

Reference: https://cron-eu.atlassian.net/browse/DAVSHOP-891